### PR TITLE
fix null latitude and longitude

### DIFF
--- a/geobroker-api/src/main/java/at/wrk/fmd/geobroker/contract/generic/Point.java
+++ b/geobroker-api/src/main/java/at/wrk/fmd/geobroker/contract/generic/Point.java
@@ -19,9 +19,9 @@ public class Point implements Serializable {
     private final Double latitude;
     private final Double longitude;
 
-    public Point(final double latitude, final double longitude) {
-        this.latitude = latitude;
-        this.longitude = longitude;
+    public Point(final Double latitude, final Double longitude) {
+        this.latitude = Objects.requireNonNull(latitude, "latitude must not be null.");
+        this.longitude = Objects.requireNonNull(longitude, "longitude must not be null.");
     }
 
     public Double getLatitude() {

--- a/geobroker-api/src/main/java/at/wrk/fmd/geobroker/contract/generic/Position.java
+++ b/geobroker-api/src/main/java/at/wrk/fmd/geobroker/contract/generic/Position.java
@@ -21,8 +21,8 @@ public class Position extends Point {
     private final Double speed;
 
     public Position(
-            final double latitude,
-            final double longitude,
+            final Double latitude,
+            final Double longitude,
             final Instant timestamp,
             final Double accuracy,
             final Double heading,

--- a/geobroker/src/test/java/at/wrk/fmd/geobroker/util/ConfiguredUnits.java
+++ b/geobroker/src/test/java/at/wrk/fmd/geobroker/util/ConfiguredUnits.java
@@ -32,8 +32,8 @@ public final class ConfiguredUnits {
                 token,
                 referencedUnitIds,
                 ImmutableList.of("referenced incident 1 " + randomAlphabetic(), "referenced incident 2 " + randomAlphabetic()),
-                new Point(new Double(123), RandomUtils.nextDouble(0, 90)),
-                new Point(new Double(938), RandomUtils.nextDouble(0, 90))
+                new Point(123d, RandomUtils.nextDouble(0, 90)),
+                new Point(938d, RandomUtils.nextDouble(0, 90))
         );
     }
 

--- a/geobroker/src/test/java/at/wrk/fmd/geobroker/util/ConfiguredUnits.java
+++ b/geobroker/src/test/java/at/wrk/fmd/geobroker/util/ConfiguredUnits.java
@@ -32,8 +32,8 @@ public final class ConfiguredUnits {
                 token,
                 referencedUnitIds,
                 ImmutableList.of("referenced incident 1 " + randomAlphabetic(), "referenced incident 2 " + randomAlphabetic()),
-                new Point(123, RandomUtils.nextDouble(0, 90)),
-                new Point(938, RandomUtils.nextDouble(0, 90))
+                new Point(new Double(123), RandomUtils.nextDouble(0, 90)),
+                new Point(new Double(938), RandomUtils.nextDouble(0, 90))
         );
     }
 


### PR DESCRIPTION
The REST operation POST `public/positions/{unitId}` accepts `null` values for `latitude` and `longitude`. I copied the pattern from `timestamp`, but the behavior remains unchanged. Can you easily fix this?