### PR TITLE
fixed warning

### DIFF
--- a/geobroker/src/main/java/at/wrk/fmd/geobroker/startup/GeobrokerPropertyConfiguration.java
+++ b/geobroker/src/main/java/at/wrk/fmd/geobroker/startup/GeobrokerPropertyConfiguration.java
@@ -18,7 +18,7 @@ public class GeobrokerPropertyConfiguration {
      * See https://jira.springsource.org/browse/SPR-8539.
      */
     @Bean
-    public PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+    public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
         return new PropertySourcesPlaceholderConfigurer();
     }
 }


### PR DESCRIPTION
Declaring the method static is suggested by the warning message.
The method is also declared static in the referenced SPR-8539.